### PR TITLE
error de autentificación

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
           user_params.permit(:username, :email, :password, :password_confirmation, :nombres, :apellido_paterno, :apellido_materno,:user_type)
         end
         devise_parameter_sanitizer.permit(:account_update) do |user_params|
-          user_params.permit(:username, :email, :password, :password_confirmation, :nombres, :apellidoPaterno, :apellidoMaterno,:user_type)
+          user_params.permit(:username, :email, :password, :password_confirmation, :nombres, :apellidoPaterno, :apellidoMaterno,:user_type,:current_password )
         end
       end
 


### PR DESCRIPTION
Agrege :current_password en el controlador de aplicaciones esto no permitia que se guardara la nueva contraseñaba cuando se trataba de actualizarla.